### PR TITLE
Made breadcrumb count visible in templates.

### DIFF
--- a/breadcrumbs/breadcrumbs.py
+++ b/breadcrumbs/breadcrumbs.py
@@ -172,6 +172,9 @@ class Breadcrumbs(Singleton):
             self.__bds.append(bd)
             self.__urls.append(bd.url)
 
+    def __len__(self):
+        return len(self.__bds)
+
     def __iter__(self):
         return iter(self.__bds)
 


### PR DESCRIPTION
I needed breadcrumbs to be visible in template only if there were more than one breadcrumb elements.
