### PR TITLE
support for projects without FlatpageFallbackMiddleware or django.contrib.sites

### DIFF
--- a/breadcrumbs/breadcrumbs.py
+++ b/breadcrumbs/breadcrumbs.py
@@ -50,30 +50,11 @@ class Breadcrumb(object):
     def __repr__(self):
         return u"Breadcrumb <%s,%s>" % (self.name, self.url)
 
-
-class Singleton(object):
-
-    __instance__ = None
-
-    def __new__(cls, *a, **kw):
-        if Singleton.__instance__ is None:
-            Singleton.__instance__ = object.__new__(cls, *a, **kw)
-            cls._Singleton__instance = Singleton.__instance__
-        return Singleton.__instance__
-
-    def _drop_it(self):
-        Singleton.__instance__ = None
-
-
-class Breadcrumbs(Singleton):
+class Breadcrumbs(object):
     """
     Breadcrumbs maintain a list of breadcrumbs that you can get interating with
     class or with get_breadcrumbs().
     """
-    __bds = []
-    __autohome = getattr(settings, 'BREADCRUMBS_AUTO_HOME', False)
-    __urls = []
-    __started = False
 
     def __call__(self, *args, **kwargs):
         if not len(args) and not len(kwargs):
@@ -128,9 +109,7 @@ class Breadcrumbs(Singleton):
         Call validate and if ok, call fill bd
         """
         super(Breadcrumbs, self).__init__(*a, **kw)
-        if not self.__started:
-            self._clean()
-            self.__started = True
+        self._clean()
         if a or kw:
             self._add(*a, **kw)
 

--- a/breadcrumbs/middleware.py
+++ b/breadcrumbs/middleware.py
@@ -3,14 +3,20 @@ from django.conf import settings
 from django.http import Http404
 from .breadcrumbs import Breadcrumbs
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:  # Django < 1.10
+    # Works perfectly for everyone using MIDDLEWARE_CLASSES
+    MiddlewareMixin = object
 
-class BreadcrumbsMiddleware(object):
+
+class BreadcrumbsMiddleware(MiddlewareMixin):
     def process_request(self, request):
         if not hasattr(request, 'breadcrumbs'):
             request.breadcrumbs = Breadcrumbs()
 
 
-class FlatpageFallbackMiddleware(object):
+class FlatpageFallbackMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         # do nothing if flatpages middleware isn't enabled, also if response
         # code isn't 404.

--- a/breadcrumbs/middleware.py
+++ b/breadcrumbs/middleware.py
@@ -2,11 +2,9 @@
 from django.conf import settings
 from django.http import Http404
 from .breadcrumbs import Breadcrumbs
-from .views import flatpage
 
 
 class BreadcrumbsMiddleware(object):
-
     def process_request(self, request):
         request.breadcrumbs = Breadcrumbs()
         request.breadcrumbs._clean()
@@ -19,6 +17,7 @@ class FlatpageFallbackMiddleware(object):
         if response.status_code != 404:
             return response
         try:
+            from .views import flatpage
             return flatpage(request, request.path_info)
         # Return the original response if any errors happened. Because this
         # is a middleware, we can't assume the errors will be caught elsewhere.

--- a/breadcrumbs/middleware.py
+++ b/breadcrumbs/middleware.py
@@ -7,7 +7,6 @@ from .breadcrumbs import Breadcrumbs
 class BreadcrumbsMiddleware(object):
     def process_request(self, request):
         request.breadcrumbs = Breadcrumbs()
-        request.breadcrumbs._clean()
 
 
 class FlatpageFallbackMiddleware(object):

--- a/breadcrumbs/middleware.py
+++ b/breadcrumbs/middleware.py
@@ -6,7 +6,8 @@ from .breadcrumbs import Breadcrumbs
 
 class BreadcrumbsMiddleware(object):
     def process_request(self, request):
-        request.breadcrumbs = Breadcrumbs()
+        if not hasattr(request, 'breadcrumbs'):
+            request.breadcrumbs = Breadcrumbs()
 
 
 class FlatpageFallbackMiddleware(object):


### PR DESCRIPTION
FlatpageFallbackMiddleware shouldn't be mandatory
